### PR TITLE
 Added Dark/Light Theme Toggle to Navbar – Closes #1

### DIFF
--- a/client/src/components/AQICard.jsx
+++ b/client/src/components/AQICard.jsx
@@ -10,20 +10,22 @@ const getAQIDescription = (aqi) => {
 };
 
 const getCardColor = (aqi) => {
-  if (aqi <= 50) return "bg-green-500 text-white hover:bg-green-600/85";
-  if (aqi <= 100) return "bg-yellow-400 text-black hover:bg-yellow-500/85";
-  if (aqi <= 200) return "bg-orange-400 text-white hover:bg-orange-500/85";
-  if (aqi <= 300) return "bg-red-500 text-white hover:bg-red-600/85";
-  if (aqi <= 400) return "bg-red-800 text-white hover:bg-red-900/85";
-  return "bg-black text-white";
+  if (aqi <= 50)
+    return "bg-green-500 text-white hover:bg-green-600 dark:bg-green-400 dark:hover:bg-green-500";
+  if (aqi <= 100)
+    return "bg-yellow-400 text-black hover:bg-yellow-500 dark:bg-yellow-300 dark:text-black";
+  if (aqi <= 200)
+    return "bg-orange-400 text-white hover:bg-orange-500 dark:bg-orange-300 dark:text-black";
+  if (aqi <= 300)
+    return "bg-red-500 text-white hover:bg-red-600 dark:bg-red-400 dark:text-white";
+  if (aqi <= 400)
+    return "bg-red-800 text-white hover:bg-red-900 dark:bg-red-700";
+  return "bg-black text-white dark:bg-gray-800";
 };
 
 const AQICard = ({ aqi, city, time }) => {
   const cardColor = getCardColor(aqi);
-
-  // Ensure `time` is valid, and fallback if `time.iso` is missing
-  const formattedTime =
-    time ? new Date(time).toLocaleString() : "N/A";
+  const formattedTime = time ? new Date(time).toLocaleString() : "N/A";
 
   return (
     <div
@@ -35,7 +37,7 @@ const AQICard = ({ aqi, city, time }) => {
         <p className="text-xl font-medium mt-2">{getAQIDescription(aqi)}</p>
       </div>
 
-      <p className="text-xs mt-2 opacity-70">
+      <p className="text-xs mt-2 opacity-80">
         <span className="font-medium">Last Updated: </span>
         {formattedTime}
       </p>

--- a/client/src/components/AQIScaleTable.jsx
+++ b/client/src/components/AQIScaleTable.jsx
@@ -50,13 +50,13 @@ const aqiLevels = [
 ];
 
 const AQIScaleTable = () => (
-  <div className="bg-white/60 backdrop-blur-lg p-6 rounded-xl shadow-md w-full">
-    <h3 className="text-2xl font-bold mb-6 text-gray-800">
+  <div className="bg-white/60 dark:bg-gray-900/60 backdrop-blur-lg p-6 rounded-xl shadow-md w-full">
+    <h3 className="text-2xl font-bold mb-6 text-gray-800 dark:text-white">
       AQI Scale & Health Impact Guide
     </h3>
     <div className="overflow-x-auto">
       <table className="w-full text-left text-base border-collapse overflow-hidden">
-        <thead className="bg-gray-100 text-gray-700">
+        <thead className="bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-200">
           <tr>
             <th className="py-3 px-4">Level</th>
             <th className="py-3 px-4">Range</th>
@@ -68,7 +68,7 @@ const AQIScaleTable = () => (
           {aqiLevels.map((item, index) => (
             <tr
               key={index}
-              className="border-b border-gray-300 hover:bg-gray-100 hover:scale-[1.01] transition-all duration-200 ease-in-out"
+              className="border-b border-gray-300 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800 hover:scale-[1.01] transition-all duration-200 ease-in-out"
             >
               <td className="py-4 px-4">
                 <span
@@ -77,11 +77,13 @@ const AQIScaleTable = () => (
                   {item.level}
                 </span>
               </td>
-              <td className="py-4 px-4 font-medium text-gray-800">
+              <td className="py-4 px-4 font-medium text-gray-800 dark:text-gray-100">
                 {item.range}
               </td>
-              <td className="py-4 px-4 text-gray-700">{item.health}</td>
-              <td className="py-4 px-4 text-gray-600 italic">
+              <td className="py-4 px-4 text-gray-700 dark:text-gray-300">
+                {item.health}
+              </td>
+              <td className="py-4 px-4 text-gray-600 dark:text-gray-400 italic">
                 {item.sensitive}
               </td>
             </tr>

--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -5,7 +5,7 @@ import Navbar from "./Navbar";
 
 const Layout = () => {
   return (
-    <div className="bg-gray-100 text-gray-900 min-h-screen">
+    <div className="bg-gray-100 text-gray-900 dark:bg-gray-800 dark:text-white min-h-screen transition-colors duration-300">
       <Navbar />
       <main className="p-4 max-w-5xl mx-auto">
         <Outlet />

--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -1,33 +1,47 @@
 // components/Navbar.jsx
 import React from "react";
 import { Link, useLocation } from "react-router";
+import { useTheme } from "../hooks/useTheme";
+import { Sun, Moon } from "lucide-react";
 
 const Navbar = () => {
+  const { theme, toggleTheme } = useTheme();
   const location = useLocation();
 
   const navLinkClass = (path) =>
-    `px-4 py-2 rounded-lg transition ${
-      location.pathname === path
-        ? "bg-emerald-500 text-white"
-        : "hover:bg-emerald-100"
+    `px-4 py-2 rounded-lg transition-all font-medium
+    ${location.pathname === path
+      ? "dark:bg-purple-600 dark:text-white bg-emerald-500 text-white"
+      : "dark:hover:bg-purple-700 dark:text-gray-100 hover:bg-emerald-100 text-gray-800"
     }`;
 
   return (
-    <nav className="flex items-center justify-between px-6 py-4 shadow-md bg-white">
-      <h1 className="text-2xl font-bold text-emerald-600">BreatheEasy</h1>
+    <nav
+      className={`sticky top-0 z-50 flex items-center justify-between px-6 py-4 shadow-md transition-all dark:bg-gray-900 dark:text-white bg-white text-black`}
+    >
+      <h1
+        className={`text-2xl font-bold transition-colors dark:text-purple-400 text-emerald-600`}
+      >
+        BreatheEasy
+      </h1>
+
       <div className="flex items-center space-x-3 flex-wrap">
-        <Link to="/" className={navLinkClass("/")}>
-          Dashboard
-        </Link>
-        <Link to="/precautions" className={navLinkClass("/precautions")}>
-          Precautions
-        </Link>
-        <Link to="/improvement" className={navLinkClass("/improvement")}>
-          Improvement
-        </Link>
-        <Link to="/chart" className={navLinkClass("/chart")}>
-          Air Quality Forecast
-        </Link>
+        <Link to="/" className={navLinkClass("/")}>Dashboard</Link>
+        <Link to="/precautions" className={navLinkClass("/precautions")}>Precautions</Link>
+        <Link to="/improvement" className={navLinkClass("/improvement")}>Improvement</Link>
+        <Link to="/chart" className={navLinkClass("/chart")}>Air Quality Forecast</Link>
+
+        <button
+          onClick={toggleTheme}
+          className="transition-all duration-300 cursor-pointer flex items-center justify-center px-3 py-2 rounded-full border bg-white border-green-400 text-green-800 hover:bg-green-100 dark:bg-purple-800 dark:border-purple-600 dark:text-white dark:hover:bg-purple-700"
+
+        >
+          {theme === 'dark' ? (
+            <Sun className="w-5 h-5 text-yellow-400" />
+          ) : (
+            <Moon className="w-5 h-5 text-blue-600" />
+          )}
+        </button>
       </div>
     </nav>
   );

--- a/client/src/components/PollutantDetails.jsx
+++ b/client/src/components/PollutantDetails.jsx
@@ -30,8 +30,8 @@ const pollutantLabels = {
 };
 
 const PollutantDetails = ({ components }) => (
-  <div className="bg-white/70 backdrop-blur-xl p-6 rounded-2xl shadow-md">
-    <h3 className="text-xl font-semibold mb-5 text-gray-800">
+  <div className="bg-white/70 dark:bg-gray-700/70 backdrop-blur-xl p-6 rounded-2xl shadow-md">
+    <h3 className="text-xl font-semibold mb-5 text-gray-800 dark:text-white">
       Pollutant Details
     </h3>
     <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-5">
@@ -44,15 +44,21 @@ const PollutantDetails = ({ components }) => (
         return (
           <div
             key={key}
-            className="flex items-center justify-between bg-white rounded-xl px-4 py-3 shadow-sm border border-gray-200 hover:shadow-md transition"
+            className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-md border border-gray-200 dark:border-gray-700 transition hover:shadow-lg"
           >
-            <div className="flex items-center gap-3">
-              {icon}
-              <span className="text-sm font-medium text-gray-700">{label}</span>
+            <div className="flex items-center gap-4 mb-3">
+              <div className="p-2 rounded-full bg-muted dark:bg-gray-700">
+                {icon}
+              </div>
+              <h4 className="text-base font-semibold text-gray-800 dark:text-gray-100">
+                {label}
+              </h4>
             </div>
-            <span className="text-sm px-3 py-1 bg-gray-100 rounded-full font-semibold text-gray-800">
-              {value} μg/m³
-            </span>
+            <div className="mt-1 text-center">
+              <div className="inline-block px-4 py-1 rounded-full bg-emerald-100 dark:bg-purple-700/50 text-sm font-semibold text-emerald-800 dark:text-white">
+                {value} μg/m³
+              </div>
+            </div>
           </div>
         );
       })}

--- a/client/src/components/Suggestions.jsx
+++ b/client/src/components/Suggestions.jsx
@@ -7,14 +7,14 @@ const getSuggestionDetails = (aqi) => {
       icon: <Smile className="text-green-500 w-5 h-5" />,
       title: "Good Air Quality",
       advice: "Enjoy your day! Ideal conditions for outdoor activities.",
-      bg: "bg-green-100",
+      bg: "bg-green-100 dark:bg-green-900/30",
     };
   } else if (aqi <= 100) {
     return {
       icon: <AlertCircle className="text-yellow-500 w-5 h-5" />,
       title: "Fair Air Quality",
       advice: "Sensitive groups should limit extended outdoor exposure.",
-      bg: "bg-yellow-100",
+      bg: "bg-yellow-100 dark:bg-yellow-900/30",
     };
   } else if (aqi <= 150) {
     return {
@@ -22,21 +22,21 @@ const getSuggestionDetails = (aqi) => {
       title: "Moderate Pollution",
       advice:
         "Limit prolonged outdoor exertion. Children and elderly should be cautious.",
-      bg: "bg-orange-100",
+      bg: "bg-orange-100 dark:bg-orange-900/30",
     };
   } else if (aqi <= 200) {
     return {
       icon: <Frown className="text-red-500 w-5 h-5" />,
       title: "Poor Air Quality",
       advice: "Avoid outdoor activities. Wear a mask if going out.",
-      bg: "bg-red-100",
+      bg: "bg-red-100 dark:bg-red-900/30",
     };
   } else {
     return {
-      icon: <ShieldOff className="text-red-800 w-5 h-5" />,
+      icon: <ShieldOff className="text-red-800 w-5 h-5 dark:text-red-300" />,
       title: "Very Poor Air Quality",
       advice: "Stay indoors with air purifiers. Keep windows shut.",
-      bg: "bg-red-800/20",
+      bg: "bg-red-800/20 dark:bg-red-900/40",
     };
   }
 };
@@ -48,9 +48,11 @@ const Suggestions = ({ aqi }) => {
     <div className={`${bg} p-4 rounded-xl shadow-md`}>
       <div className="flex items-center gap-2 mb-2">
         {icon}
-        <h3 className="text-lg font-semibold text-gray-800">{title}</h3>
+        <h3 className="text-lg font-semibold text-gray-800 dark:text-white">
+          {title}
+        </h3>
       </div>
-      <p className="text-gray-700">{advice}</p>
+      <p className="text-gray-700 dark:text-gray-300">{advice}</p>
     </div>
   );
 };

--- a/client/src/hooks/useTheme.js
+++ b/client/src/hooks/useTheme.js
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+
+export const useTheme = () => {
+    const [theme, setTheme] = useState('light');
+
+    useEffect(() => {
+        const savedTheme = localStorage.getItem('theme');
+        const initialTheme = savedTheme === 'dark' ? 'dark' : 'light';
+
+        document.documentElement.classList.add(initialTheme);
+        document.documentElement.classList.remove(initialTheme === 'dark' ? 'light' : 'dark');
+        setTheme(initialTheme);
+    }, []);
+
+    const toggleTheme = () => {
+        const isDark = theme === 'dark';
+        const newTheme = isDark ? 'light' : 'dark';
+
+        document.documentElement.classList.remove(theme);
+        document.documentElement.classList.add(newTheme);
+        localStorage.setItem('theme', newTheme);
+        setTheme(newTheme);
+    };
+
+    return { theme, toggleTheme };
+};

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 
+@custom-variant dark (&:where(.dark, .dark *));
 
   /* Navbar link hover effect */
 .navbar-link:hover {

--- a/client/src/pages/AirQualityChart.jsx
+++ b/client/src/pages/AirQualityChart.jsx
@@ -68,6 +68,7 @@ const AirQualityChart = () => {
       legend: {
         position: "top",
         labels: {
+          color: "#555", // default
           font: {
             size: 14,
           },
@@ -80,11 +81,17 @@ const AirQualityChart = () => {
     },
     scales: {
       x: {
+        ticks: {
+          color: "#666",
+        },
         grid: {
           display: false,
         },
       },
       y: {
+        ticks: {
+          color: "#666",
+        },
         grid: {
           color: "rgba(200, 200, 200, 0.2)",
         },
@@ -94,8 +101,8 @@ const AirQualityChart = () => {
   };
 
   return (
-    <div className="bg-white/80 backdrop-blur-xl p-8 rounded-3xl shadow-lg w-full max-w-6xl mx-auto">
-      <h3 className="text-2xl font-bold mb-6 text-gray-800 text-center">
+    <div className="bg-white/80 dark:bg-gray-900/80 backdrop-blur-xl p-8 rounded-3xl shadow-lg w-full max-w-6xl mx-auto">
+      <h3 className="text-2xl font-bold mb-6 text-gray-800 dark:text-white text-center">
         Air Quality Forecast (Next 7 Days)
       </h3>
       <div className="h-[500px]">

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -24,26 +24,32 @@ const Dashboard = () => {
 
   return (
     <div className="space-y-8">
-      <h2 className="text-2xl font-bold text-emerald-500 mt-4">Your Location Air Quality</h2>
-      {aqiData ? (
-        <>
-          <p className="text-md text-black font-semibold italic bg-gray-200 p-6 rounded-2xl">{aqiData.city}</p>
+  <h2 className="text-2xl font-bold text-emerald-500 dark:text-purple-400 mt-4">
+    Your Location Air Quality
+  </h2>
 
-          {/* Bento grid layout for AQI and Pollutants */}
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-            <AQICard aqi={aqiData.aqi} city={aqiData.city} time={aqiData.time}/>
-            <div className="lg:col-span-2">
-              <PollutantDetails components={aqiData.components} />
-            </div>
-          </div>
+  {aqiData ? (
+    <>
+      <p className="text-md text-black dark:text-white font-semibold italic bg-gray-200 dark:bg-gray-700 p-6 rounded-2xl">
+        {aqiData.city}
+      </p>
 
-          <Suggestions aqi={aqiData.aqi} />
-          <AQIScaleTable />
-        </>
-      ) : (
-        <p>Loading AQI data...</p>
-      )}
-    </div>
+      {/* Bento grid layout for AQI and Pollutants */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <AQICard aqi={aqiData.aqi} city={aqiData.city} time={aqiData.time} />
+        <div className="lg:col-span-2">
+          <PollutantDetails components={aqiData.components} />
+        </div>
+      </div>
+
+      <Suggestions aqi={aqiData.aqi} />
+      <AQIScaleTable />
+    </>
+  ) : (
+    <p className="text-black dark:text-white">Loading AQI data...</p>
+  )}
+</div>
+
   );
 };
 

--- a/client/src/pages/ImprovementMeasures.jsx
+++ b/client/src/pages/ImprovementMeasures.jsx
@@ -47,20 +47,20 @@ const ImprovementMeasures = () => {
   const measures = aqi !== null ? getMeasures(aqi) : [];
 
   return (
-    <div className="bg-white rounded-3xl shadow-xl p-8 max-w-4xl mx-auto">
-      <h2 className="text-3xl font-bold text-emerald-600 mb-6">
+    <div className="my-20 bg-white dark:bg-gray-900 rounded-3xl shadow-xl p-8 max-w-4xl mx-auto">
+      <h2 className="text-3xl font-bold text-emerald-600 dark:text-purple-400 mb-6">
         Improvement Measures
       </h2>
 
       {aqi === null ? (
-        <p className="text-gray-500">Loading AQI data...</p>
+        <p className="text-gray-500 dark:text-gray-400">Loading AQI data...</p>
       ) : (
         <div className="space-y-6">
-          <div className="bg-emerald-50 border-l-4 border-emerald-500 p-4 rounded-lg">
-            <p className="text-lg font-medium text-emerald-800 mb-2">
+          <div className="bg-emerald-50 dark:bg-emerald-900/20 border-l-4 border-emerald-500 dark:border-emerald-400 p-4 rounded-lg">
+            <p className="text-lg font-medium text-emerald-800 dark:text-emerald-300 mb-2">
               Actions You Can Take:
             </p>
-            <ul className="list-disc pl-6 text-gray-700 space-y-2">
+            <ul className="list-disc pl-6 text-gray-700 dark:text-gray-200 space-y-2">
               {measures.map((item, i) => (
                 <li key={i} className="leading-relaxed">
                   {item}
@@ -69,11 +69,11 @@ const ImprovementMeasures = () => {
             </ul>
           </div>
 
-          <div className="bg-blue-50 border-l-4 border-blue-500 p-4 rounded-lg">
-            <h3 className="font-semibold text-blue-700 mb-2">
+          <div className="bg-blue-50 dark:bg-blue-900/20 border-l-4 border-blue-500 dark:border-blue-400 p-4 rounded-lg">
+            <h3 className="font-semibold text-blue-700 dark:text-blue-300 mb-2">
               🌍 Want to do more?
             </h3>
-            <ul className="list-disc pl-6 text-gray-700 space-y-1">
+            <ul className="list-disc pl-6 text-gray-700 dark:text-gray-200 space-y-1">
               <li>Join or organize local environmental drives.</li>
               <li>Educate others about pollution and climate impact.</li>
               <li>Support green startups or eco-conscious brands.</li>

--- a/client/src/pages/Precautions.jsx
+++ b/client/src/pages/Precautions.jsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from "react";
 
-// Tailored precautions based on AQI range
 const getPrecautions = (aqi) => {
   if (aqi <= 50) {
     return ["No specific precautions needed. Enjoy your day!"];
@@ -44,20 +43,20 @@ const Precautions = () => {
   }, []);
 
   return (
-    <div className="bg-white rounded-3xl shadow-xl p-8 max-w-4xl mx-auto">
-      <h2 className="text-3xl font-bold text-emerald-600 mb-6">
+    <div className="my-20 bg-white dark:bg-gray-900 rounded-3xl shadow-xl p-8 max-w-4xl mx-auto">
+      <h2 className="text-3xl font-bold text-emerald-600 dark:text-purple-400 mb-6">
         Health Precautions
       </h2>
 
       {precautions.length === 0 ? (
-        <p className="text-gray-500">Loading AQI-related precautions...</p>
+        <p className="text-gray-500 dark:text-gray-400">Loading AQI-related precautions...</p>
       ) : (
         <div className="space-y-6">
-          <div className="bg-yellow-50 border-l-4 border-yellow-500 p-4 rounded-lg">
-            <p className="text-lg font-medium text-yellow-800 mb-2">
+          <div className="bg-yellow-50 dark:bg-yellow-900/20 border-l-4 border-yellow-500 dark:border-yellow-400 p-4 rounded-lg">
+            <p className="text-lg font-medium text-yellow-800 dark:text-yellow-300 mb-2">
               Based on Current Air Quality:
             </p>
-            <ul className="list-disc pl-6 text-gray-700 space-y-2">
+            <ul className="list-disc pl-6 text-gray-700 dark:text-gray-200 space-y-2">
               {precautions.map((item, i) => (
                 <li key={i} className="leading-relaxed">
                   {item}
@@ -66,11 +65,11 @@ const Precautions = () => {
             </ul>
           </div>
 
-          <div className="bg-gray-50 border-l-4 border-gray-400 p-4 rounded-lg">
-            <h3 className="font-semibold text-gray-700 mb-2">
+          <div className="bg-gray-50 dark:bg-gray-800/40 border-l-4 border-gray-400 dark:border-gray-500 p-4 rounded-lg">
+            <h3 className="font-semibold text-gray-700 dark:text-gray-100 mb-2">
               🛡️ General Protective Measures:
             </h3>
-            <ul className="list-disc pl-6 text-gray-700 space-y-1">
+            <ul className="list-disc pl-6 text-gray-700 dark:text-gray-200 space-y-1">
               <li>Stay hydrated and eat antioxidant-rich foods.</li>
               <li>
                 Use indoor plants that help purify air (like snake plant, spider


### PR DESCRIPTION
Hi team 👋

This PR adds the much-needed **dark/light mode toggle functionality** to the navbar as requested in **Issue #1**.

---

### ✅ What's Implemented:

- 🌗 **Dark/Light Mode Toggle** added to the navbar.
- 🧠 Theme preference is **saved in localStorage**, so the user’s selection persists even after refresh or reopening the app.
- 🌍 Toggle works globally and applies across all pages of the app.
- ⚡ Smooth transition between themes for better user experience.

---

### 🖼 Before & After Snapshots:

#### ❌ Before (No Toggle, default light mode only)
<img width="1897" height="998" alt="image" src="https://github.com/user-attachments/assets/e4f9862c-cf37-4c35-948e-4384a237b7a5" />


---

#### ✅ After (Theme Toggle Present in Navbar)
<img width="1901" height="995" alt="image" src="https://github.com/user-attachments/assets/6f80b0f8-9026-4719-be1f-d1837b7c3408" />

<img width="1899" height="989" alt="image" src="https://github.com/user-attachments/assets/f53849af-30a9-4ae2-be8b-3670ddf9a6cb" />
<img width="1898" height="993" alt="image" src="https://github.com/user-attachments/assets/eec8b625-c431-4ed2-aa65-13528d2df2ab" />



---

### 🔐 How It Works:

- Toggle button is located in the **top right corner** of the navbar.
- On toggle:
  - Theme is applied across the app.
  - Preference is stored in `localStorage`.
- Responsive and accessible on all screen sizes.

---

### 🏷 Labels:

- `gssoc2025`
- `feature`
- `level 2`

Let me know if any refinements are needed.  
Thanks!
