### PR TITLE
fix(nav): Make navbar responsive on mobile devices

### DIFF
--- a/client/src/pages/LandingPage.jsx
+++ b/client/src/pages/LandingPage.jsx
@@ -135,7 +135,7 @@ const LandingPage = () => {
 
               <Link
                 to="/dashboard"
-                className="bg-emerald-600 hover:bg-emerald-700 dark:bg-green-600 dark:hover:bg-green-700 text-white px-6 py-2 rounded-lg font-medium transition-all duration-300 flex items-center gap-2"
+                className="hidden sm:flex bg-emerald-600 hover:bg-emerald-700 dark:bg-green-600 dark:hover:bg-green-700 text-white px-6 py-2 rounded-lg font-medium transition-all duration-300 items-center gap-2"
               >
                 Launch App
                 <ArrowRight className="w-4 h-4" />
@@ -525,4 +525,4 @@ const LandingPage = () => {
   );
 };
 
-export default LandingPage; 
+export default LandingPage;


### PR DESCRIPTION
## Description

This pull request addresses a UI bug where the main navigation bar was not responsive on smaller screen sizes. The "Launch App" button would cause the navigation items to wrap or overflow, breaking the layout.

The fix involves applying responsive Tailwind CSS classes to conditionally hide the "Launch App" button on mobile viewports (screens smaller than the `sm` breakpoint of 640px). This ensures the logo and the theme toggle button remain neatly aligned on opposite ends of the navbar, providing a clean and user-friendly experience on all devices.

---

## Issue Fixed

Closes: #28 

---

<img width="445" height="87" alt="image" src="https://github.com/user-attachments/assets/29965363-7981-4d52-8978-bcde9678a9c0" />


