### PR TITLE
Add Scroll-to-top Button on landing page

### DIFF
--- a/client/src/pages/LandingPage.jsx
+++ b/client/src/pages/LandingPage.jsx
@@ -17,6 +17,7 @@ import {
   Calendar
 } from "lucide-react";
 import { useTheme } from "../hooks/useTheme";
+import ScrollToTop from '../components/ScrollToTop';
 
 const LandingPage = () => {
   const { theme, toggleTheme } = useTheme();
@@ -808,6 +809,7 @@ const LandingPage = () => {
           background-size: 300% 300%;
         }
       `}</style>
+      <ScrollToTop />
     </div>
   );
 };


### PR DESCRIPTION
closes #39 
imported the same component that was previously used.

<img width="894" height="875" alt="image" src="https://github.com/user-attachments/assets/7f870abc-e253-4e79-9b4c-d34fdf68270c" />


Bottom right as you said!