### PR TITLE
Fix #59: add hover + glitter effect on Precautions

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -35,4 +35,48 @@
 .animation-delay-4000 {
   animation-delay: 4s;
 }
+
+/* Precautions page: hover + glitter (shimmer) effect */
+.precaution-card {
+  position: relative;
+  overflow: hidden;
+  will-change: transform;
+  transition: transform 200ms ease, box-shadow 200ms ease;
+}
+
+.precaution-card:hover {
+  transform: translateY(-2px);
+}
+
+.precaution-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  left: -150%;
+  width: 120%;
+  height: 100%;
+  transform: skewX(-20deg);
+  background: linear-gradient(
+    120deg,
+    transparent,
+    rgb(255 255 255 / 0.28),
+    transparent
+  );
+  opacity: 0;
+  pointer-events: none;
+}
+
+.precaution-card:hover::before {
+  opacity: 1;
+  animation: precaution-shine 900ms linear;
+}
+
+@keyframes precaution-shine {
+  from {
+    left: -150%;
+  }
+  to {
+    left: 150%;
+  }
+}
   

--- a/client/src/pages/Precautions.jsx
+++ b/client/src/pages/Precautions.jsx
@@ -85,7 +85,7 @@ const Precautions = () => {
         </p>
       ) : (
         <div className="space-y-6">
-          <div className="bg-yellow-50 dark:bg-yellow-900/20 border-l-4 border-yellow-500 dark:border-yellow-400 p-4 rounded-lg">
+          <div className="precaution-card bg-yellow-50 dark:bg-yellow-900/20 border-l-4 border-yellow-500 dark:border-yellow-400 p-4 rounded-lg">
             <p className="text-lg font-medium text-yellow-800 dark:text-yellow-300 mb-2">
               Based on Current Air Quality:
             </p>
@@ -111,7 +111,7 @@ const Precautions = () => {
             </ul>
           </div>
 
-          <div className="bg-gray-50 dark:bg-gray-800/40 border-l-4 border-gray-400 dark:border-gray-500 p-4 rounded-lg">
+          <div className="precaution-card bg-gray-50 dark:bg-gray-800/40 border-l-4 border-gray-400 dark:border-gray-500 p-4 rounded-lg">
             <h3 className="font-semibold text-gray-700 dark:text-gray-100 mb-2">
               🛡️ General Protective Measures:
             </h3>


### PR DESCRIPTION
Fixes #59

What changed

Added a simple hover lift effect and a lightweight glitter/shimmer effect (CSS-only) on the Precautions page cards.
The glitter/shimmer runs only on hover to keep it minimal and avoid unnecessary performance cost.
Files changed

[index.css](vscode-file://vscode-app/Users/preetkotmire/Downloads/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html): Added .precaution-card hover + shimmer styles.
[Precautions.jsx](vscode-file://vscode-app/Users/preetkotmire/Downloads/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html): Applied .precaution-card to the two main precaution sections.
How to verify

Go to [/dashboard/precautions](vscode-file://vscode-app/Users/preetkotmire/Downloads/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Hover over the “Based on Current Air Quality” and “General Protective Measures” sections and confirm the hover + shimmer effect appears.